### PR TITLE
Add support for access logging

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -174,4 +174,15 @@ default['jenkins']['master'].tap do |master|
   #   node.set['jenkins']['master']['log_directory'] = '/var/log/jenkins'
   #
   master['log_directory'] = '/var/log/jenkins'
+
+  #
+  # The file name for access logging into node['jenkins']['master']['log_directory'].
+  #
+  master['access_log'] = 'access_log'
+
+  #
+  # Whether to enable access logging.
+  #
+  master['access_log_enabled'] = false
+
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,5 +9,6 @@ version          '2.1.2'
 recipe 'master', 'Installs a Jenkins master'
 
 depends 'apt',   '~> 2.0'
+depends 'logrotate'
 depends 'runit', '~> 1.5'
 depends 'yum',   '~> 3.0'

--- a/recipes/_master_package.rb
+++ b/recipes/_master_package.rb
@@ -35,6 +35,20 @@ when 'debian'
     version node['jenkins']['master']['version']
   end
 
+  bash "Modify packaged log rotation directory" do
+    code <<-EOH
+      sed -i "s|/var/log/jenkins|#{node['jenkins']['master']['log_directory']}|g" /etc/logrotate.d/jenkins
+    EOH
+  end
+
+  bash "Modify packaged log rotation file name" do
+    code <<-EOH
+      if [ -z "`grep #{node['jenkins']['master']['access_log']} /etc/logrotate.d/jenkins`" ]; then
+        sed -i "s|{|#{node['jenkins']['master']['log_directory']}/#{node['jenkins']['master']['access_log']} {|" /etc/logrotate.d/jenkins
+      fi
+    EOH
+  end
+
   template '/etc/default/jenkins' do
     source   'jenkins-config-debian.erb'
     mode     '0644'
@@ -50,6 +64,25 @@ when 'rhel'
 
   package 'jenkins' do
     version node['jenkins']['master']['version']
+  end
+
+  bash "Modify packaged log rotation directory" do
+    code <<-EOH
+      sed -i "s|/var/log/jenkins|#{node['jenkins']['master']['log_directory']}|g" /etc/logrotate.d/jenkins
+    EOH
+  end
+
+  bash "Modify packaged log rotation file name" do
+    code <<-EOH
+      sed -i "s|access_log|#{node['jenkins']['master']['access_log']}|g"          /etc/logrotate.d/jenkins
+    EOH
+  end
+
+  bash "Modify packaged access log" do
+    code <<-EOH
+      sed -i "/accessLogger/ s|/var/log/jenkins|#{node['jenkins']['master']['log_directory']}|g" /etc/init.d/jenkins
+      sed -i "/accessLogger/ s|access_log|#{node['jenkins']['master']['access_log']}|g"          /etc/init.d/jenkins
+    EOH
   end
 
   template '/etc/sysconfig/jenkins' do

--- a/recipes/_master_war.rb
+++ b/recipes/_master_war.rb
@@ -50,6 +50,13 @@ directory node['jenkins']['master']['log_directory'] do
   recursive true
 end
 
+# Log rotation for access log
+logrotate_app 'jenkins' do
+  cookbook  'logrotate'
+  enable    node['jenkins']['master']['access_log_enabled']
+  path      "#{node['jenkins']['master']['log_directory']}/#{node['jenkins']['master']['access_log']}"
+end
+
 # Include runit to setup the service
 include_recipe 'runit::default'
 

--- a/templates/default/jenkins-config-debian.erb
+++ b/templates/default/jenkins-config-debian.erb
@@ -35,6 +35,13 @@ RUN_STANDALONE=true
 # log location.  this may be a syslog facility.priority
 JENKINS_LOG=<%= node['jenkins']['master']['log_directory'] %>/$NAME.log
 
+# Enable access log
+JENKINS_ENABLE_ACCESS_LOG="<%= node['jenkins']['master']['access_log_enabled'] ? 'yes' : 'no' %>"
+
+if [ "$JENKINS_ENABLE_ACCESS_LOG" = "yes" ]; then
+  JENKINS_ACCESSLOG="--accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=<%= node['jenkins']['master']['log_directory'] %>/<%= node['jenkins']['master']['access_log'] %>"
+fi
+
 # OS LIMITS SETUP
 #   comment this out to observe /etc/security/limits.conf
 #   this is on by default because http://github.com/jenkinsci/jenkins/commit/2fb288474e980d0e7ff9c4a3b768874835a3e92e
@@ -64,7 +71,7 @@ PREFIX=/jenkins
 # --webroot=~/.jenkins/war
 # --prefix=$PREFIX
 
-JENKINS_ARGS="--webroot=/var/cache/jenkins/war --httpListenAddress=$HTTP_LISTEN_ADDRESS --httpPort=$HTTP_PORT --ajp13Port=$AJP_PORT"
+JENKINS_ARGS="--webroot=/var/cache/jenkins/war --httpListenAddress=$HTTP_LISTEN_ADDRESS --httpPort=$HTTP_PORT --ajp13Port=$AJP_PORT $JENKINS_ACCESSLOG"
 <% if node['jenkins']['master']['jenkins_args'] %>
 JENKINS_ARGS="$JENKINS_ARGS <%= node['jenkins']['master']['jenkins_args'] %>"
 <% end %>

--- a/templates/default/jenkins-config-rhel.erb
+++ b/templates/default/jenkins-config-rhel.erb
@@ -113,7 +113,7 @@ JENKINS_DEBUG_LEVEL="5"
 #
 # Whether to enable access logging or not.
 #
-JENKINS_ENABLE_ACCESS_LOG="no"
+JENKINS_ENABLE_ACCESS_LOG="<%= node['jenkins']['master']['access_log_enabled'] ? 'yes' : 'no' %>"
 
 ## Type:        integer
 ## Default:     100

--- a/templates/default/sv-jenkins-run.erb
+++ b/templates/default/sv-jenkins-run.erb
@@ -15,4 +15,7 @@ exec chpst -u <%= node['jenkins']['master']['user'] %> -U <%= node['jenkins']['m
   <%= node['jenkins']['java'] %> <%= node['jenkins']['master']['jvm_options'] %> -jar jenkins.war \
   --httpPort=<%= node['jenkins']['master']['port'] %> \
   --httpListenAddress=<%= node['jenkins']['master']['listen_address'] %> \
+<% if node['jenkins']['master']['access_log_enabled'] %>
+  --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=<%= node['jenkins']['master']['log_directory'] %>/<%= node['jenkins']['master']['access_log'] %> \
+<% end %>
   <%= node['jenkins']['master']['jenkins_args'] %>


### PR DESCRIPTION
There isn't currently a standard technique for enabling a Jenkins access log across the various installation methods that this cookbook supports:
* rpm packages do support a setting JENKINS_ENABLE_ACCESS_LOG, however the path and file name are hardcoded
* Debian packages are missing any support per [JENKINS-18870](https://issues.jenkins-ci.org/browse/JENKINS-18870)
* war installation provides no access log support

This pull request adds two new attributes that provision a standardized access logging capability across the above installation methods:
* node['jenkins']['master']['access_log'] - the filename of the access log
* node['jenkins']['master']['access_log_enabled'] - whether to provision access logging or not

See also https://wiki.jenkins-ci.org/display/JENKINS/Access+Logging
