### PR TITLE
Encoding::InvalidByteSequenceError when using jenkins_plugin resource

### DIFF
--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -360,7 +360,7 @@ EOH
     def plugin_universe
       @plugin_universe ||= begin
         ensure_update_center_present!
-        JSON.parse(IO.read(extracted_update_center_json))['plugins']
+        JSON.parse(IO.read(extracted_update_center_json).force_encoding('UTF-8'))['plugins']
       end
     end
 


### PR DESCRIPTION
On a test system using the Jenkins cookbook, I am unable to converge jenkins_plugin resources.  Parsing the json from the update center fails with an Encoding::InvalidByteSequenceError.

I've recreated the problem with the chef omnibus package versions 11.12.8-2 and 12.0.1-1.  In both cases, I'm running on CentOS 6.5.

Error log:
```
================================================================================
Error executing action `install` on resource 'jenkins_plugin[ansicolor]'
================================================================================


Encoding::InvalidByteSequenceError
----------------------------------
"\xC5" on US-ASCII


Cookbook Trace:
---------------
/tmp/kitchen/cache/cookbooks/jenkins/libraries/plugin.rb:363:in `plugin_universe'
/tmp/kitchen/cache/cookbooks/jenkins/libraries/plugin.rb:252:in `install_plugin_from_update_center'
/tmp/kitchen/cache/cookbooks/jenkins/libraries/plugin.rb:124:in `block (2 levels) in <class:JenkinsPlugin>'
/tmp/kitchen/cache/cookbooks/jenkins/libraries/plugin.rb:155:in `block in <class:JenkinsPlugin>'


Resource Declaration:
---------------------
# In /tmp/kitchen/cache/cookbooks/platform-jenkins/recipes/master.rb

 85: jenkins_plugin 'ansicolor' do
 86:   action [ :install ]
 87:   notifies :restart, 'service[jenkins]'
 88: end
 89:



Compiled Resource:
------------------
# Declared in /tmp/kitchen/cache/cookbooks/platform-jenkins/recipes/master.rb:85:in `from_file'

jenkins_plugin("ansicolor") do
  action [:install]
  retries 0
  retry_delay 2
  guard_interpreter :default
  cookbook_name "platform-jenkins"
  recipe_name "master"
  version :latest
  install_deps true
end



[2014-12-15T16:04:56+00:00] INFO: Running queued delayed notifications before re-raising exception

Running handlers:
[2014-12-15T16:04:56+00:00] ERROR: Running exception handlers
Running handlers complete

[2014-12-15T16:04:56+00:00] ERROR: Exception handlers complete
[2014-12-15T16:04:56+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
Chef Client failed. 0 resources updated in 9.591596858 seconds
[2014-12-15T16:04:56+00:00] ERROR: jenkins_plugin[ansicolor] (platform-jenkins::master line 85) had an error: Encoding::InvalidByteSequenceError: "\xC5" on US-ASCII
[2014-12-15T16:04:56+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

Stack trace:
```
Generated at 2014-12-15 16:04:56 +0000
Encoding::InvalidByteSequenceError: jenkins_plugin[ansicolor] (platform-jenkins::master line 85) had an error: Encoding::InvalidByteSequenceError: "\xC5" on US-ASCII
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/json-1.8.1/lib/json/common.rb:155:in `encode'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/json-1.8.1/lib/json/common.rb:155:in `initialize'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/json-1.8.1/lib/json/common.rb:155:in `new'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/json-1.8.1/lib/json/common.rb:155:in `parse'
/tmp/kitchen/cache/cookbooks/jenkins/libraries/plugin.rb:363:in `plugin_universe'
/tmp/kitchen/cache/cookbooks/jenkins/libraries/plugin.rb:252:in `install_plugin_from_update_center'
/tmp/kitchen/cache/cookbooks/jenkins/libraries/plugin.rb:124:in `block (2 levels) in <class:JenkinsPlugin>'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/mixin/why_run.rb:52:in `call'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/mixin/why_run.rb:52:in `add_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/provider.rb:155:in `converge_by'
/tmp/kitchen/cache/cookbooks/jenkins/libraries/plugin.rb:155:in `block in <class:JenkinsPlugin>'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/provider/lwrp_base.rb:138:in `instance_eval'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/provider/lwrp_base.rb:138:in `block in action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/provider.rb:120:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource.rb:637:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/runner.rb:49:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/runner.rb:81:in `block (2 levels) in converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/runner.rb:81:in `each'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/runner.rb:81:in `block in converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection.rb:98:in `block in execute_each_resource'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection/stepable_iterator.rb:116:in `call'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection.rb:96:in `execute_each_resource'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/runner.rb:80:in `converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/client.rb:345:in `converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/client.rb:431:in `do_run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/client.rb:213:in `block in run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/client.rb:207:in `fork'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/client.rb:207:in `run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/application.rb:217:in `run_chef_client'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/application/client.rb:328:in `block in run_application'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/application/client.rb:317:in `loop'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/application/client.rb:317:in `run_application'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/application.rb:67:in `run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/bin/chef-client:26:in `<top (required)>'
/usr/bin/chef-client:23:in `load'
/usr/bin/chef-client:23:in `<main>'
```