### PR TITLE
Jenkins JNLP system user

### DIFF
--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -145,6 +145,7 @@ class Chef
     def group_resource
       return @group_resource if @group_resource
       @group_resource = Chef::Resource::Group.new(new_resource.group, run_context)
+      @group_resource.system(node['jenkins']['master']['use_system_accounts'])
       @group_resource
     end
 
@@ -161,6 +162,7 @@ class Chef
       @user_resource.gid(new_resource.group)
       @user_resource.comment('Jenkins slave user - Created by Chef')
       @user_resource.home(new_resource.remote_fs)
+      @user_resource.system(node['jenkins']['master']['use_system_accounts'])
       @user_resource
     end
 


### PR DESCRIPTION
This makes the jenkins jnlp slave user a system user, so it's UID doesn't conflict with later users.This pull-request has the same effect as #257 but for jenkins JNLP slaves.