### PR TITLE
Added support for jvm_options on slave_ssh resource

### DIFF
--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -78,6 +78,8 @@ class Chef
       default: 'jenkins'
     attribute :jvm_options,
       kind_of: String
+    attribute :java_path,
+              kind_of: String
 
     attr_writer :exists
     attr_writer :connected

--- a/libraries/slave_ssh.rb
+++ b/libraries/slave_ssh.rb
@@ -80,6 +80,7 @@ class Chef
         @current_resource.port(current_slave[:port])
         @current_resource.credentials(current_slave[:credentials])
         @current_resource.jvm_options(current_slave[:jvm_options])
+        @current_resource.java_path(current_slave[:java_path])
       end
 
       @current_resource
@@ -101,7 +102,7 @@ class Chef
             #{convert_to_groovy(new_resource.port)},
             credentials,
             #{convert_to_groovy(new_resource.jvm_options)},
-            null,
+            #{convert_to_groovy(new_resource.java_path)},
             #{convert_to_groovy(new_resource.command_prefix)},
             #{convert_to_groovy(new_resource.command_suffix)}
           )
@@ -116,6 +117,7 @@ class Chef
         host: 'slave.launcher.host',
         port: 'slave.launcher.port',
         jvm_options: 'slave.launcher.jvmOptions',
+        java_path: 'slave.launcher.javaPath',
         command_prefix: 'slave.launcher.prefixStartSlaveCmd',
         command_suffix: 'slave.launcher.suffixStartSlaveCmd',
       }

--- a/test/fixtures/cookbooks/jenkins_slave/recipes/create_ssh.rb
+++ b/test/fixtures/cookbooks/jenkins_slave/recipes/create_ssh.rb
@@ -60,6 +60,7 @@ jenkins_ssh_slave 'ssh-builder' do
   remote_fs   '/tmp/slave-ssh-builder'
   labels      %w(builer linux)
   user        'jenkins-ssh-key'
+  java_path    '/usr/bin/java'
   # SSH specific attributes
   host        'localhost'
   credentials credentials

--- a/test/integration/jenkins_slave_create/serverspec/assert_ssh_created_spec.rb
+++ b/test/integration/jenkins_slave_create/serverspec/assert_ssh_created_spec.rb
@@ -11,6 +11,7 @@ describe jenkins_slave('ssh-builder') do
   it { should have_host('localhost') }
   it { should have_port(22) }
   it { should have_credentials('jenkins-ssh-key') }
+  it { should have_java_path('/usr/bin/java') }
   it { should be_connected }
   it { should be_online }
 end

--- a/test/shared/support/jenkins_slave.rb
+++ b/test/shared/support/jenkins_slave.rb
@@ -80,6 +80,10 @@ module Serverspec
         port === try { xml.elements['//port'].text.to_i }
       end
 
+      def has_java_path?(path)
+        path === try { xml.elements['//javaPath'].text }
+      end
+
       def has_credentials?(credentials)
         credentials_id = try { xml.elements['//credentialsId'].text }
         credentials_xml = credentials_xml_for_id(credentials_id)


### PR DESCRIPTION
This adds support for a new `java_path` option when using the `slave` resource, analagous to the `jvm_options` option.