### PR TITLE
Allow users to turn off repository creation for package install

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -38,6 +38,14 @@ default['jenkins']['master'].tap do |master|
                              end
 
   #
+  # Allow users to specify using inbuilt repositories for installing
+  # jenkins as a package
+  #
+  #   node.set['jenkins']['master']['install_repositories'] = true
+  #
+  master['install_repositories'] = true
+
+  #
   # The version of the Jenkins master to install. This can be a specific
   # package version (from the yum or apt repo), or the version of the war
   # file to download from the Jenkins mirror.

--- a/recipes/_master_package.rb
+++ b/recipes/_master_package.rb
@@ -29,6 +29,7 @@ when 'debian'
     uri          'http://pkg.jenkins-ci.org/debian'
     distribution 'binary/'
     key          'https://jenkins-ci.org/debian/jenkins-ci.org.key'
+    only_if node['jenkins']['master']['install_repositories']
   end
 
   package 'jenkins' do
@@ -46,6 +47,7 @@ when 'rhel'
   yum_repository 'jenkins-ci' do
     baseurl 'http://pkg.jenkins-ci.org/redhat'
     gpgkey  'https://jenkins-ci.org/redhat/jenkins-ci.org.key'
+    only_if node['jenkins']['master']['install_repositories']
   end
 
   package 'jenkins' do


### PR DESCRIPTION
This aims to allow users to opt-out of yum_repos and apt_repos being created for package install.

Adding repositories to the outside world is not always an option or allowed when using Jenkins internally within a company.