### PR TITLE
Add Jenkins cli username and password support

### DIFF
--- a/attributes/executor.rb
+++ b/attributes/executor.rb
@@ -51,7 +51,7 @@ default['jenkins']['executor'].tap do |executor|
   # It is best to set this in a spot within your cookbook after an authentication scheme is activated
   # Otherwise, Jenkins wont understand the --username flag
   #
-  executor['cli_user'] = nil
+  executor['cli_username'] = nil
 
   #
   # This is the user name you wish to use to authenticate with the Jenkins CLI

--- a/attributes/executor.rb
+++ b/attributes/executor.rb
@@ -44,4 +44,20 @@ default['jenkins']['executor'].tap do |executor|
   # Please see the +Proxies+ section of the README for more information.
   #
   executor['proxy'] = nil
+
+  #
+  # This is the user name you wish to use to authenticate with the Jenkins CLI
+  # If left nil, no user will be specified (anonymous).
+  # It is best to set this in a spot within your cookbook after an authentication scheme is activated
+  # Otherwise, Jenkins wont understand the --username flag
+  #
+  executor['cli_user'] = nil
+
+  #
+  # This is the user name you wish to use to authenticate with the Jenkins CLI
+  # If left nil, no password will be used.
+  # It is best to set this in a spot within your cookbook after an authentication scheme is activated
+  # Otherwise, Jenkins wont understand the --password flag
+  #
+  executor['cli_password'] = nil
 end

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -75,8 +75,8 @@ module Jenkins
       command << %Q(-i "#{options[:key]}")                if options[:key]
       command << %Q(-p #{uri_escape(options[:proxy])})    if options[:proxy]
       command.push(pieces)
-      command << %Q(--username #{cli_user}) if options[:cli_user]
-      command << %Q(--password #{cli_password}) if options[:cli_password]
+      command << %Q(--username #{options[:cli_username]}) if options[:cli_username]
+      command << %Q(--password #{options[:cli_password]}) if options[:cli_password]
 
       begin
         cmd = Mixlib::ShellOut.new(command.join(' '), command_options.merge(timeout: options[:timeout]))

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -75,6 +75,8 @@ module Jenkins
       command << %Q(-i "#{options[:key]}")                if options[:key]
       command << %Q(-p #{uri_escape(options[:proxy])})    if options[:proxy]
       command.push(pieces)
+      command << %Q(--username #{cli_user}) if options[:cli_user]
+      command << %Q(--password #{cli_password}) if options[:cli_password]
 
       begin
         cmd = Mixlib::ShellOut.new(command.join(' '), command_options.merge(timeout: options[:timeout]))

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -76,7 +76,7 @@ module Jenkins
       command << %Q(-p #{uri_escape(options[:proxy])})    if options[:proxy]
       command.push(pieces)
       command << %Q(--username #{options[:cli_username]}) if options[:cli_username]
-      command << %Q(--password #{options[:cli_password]}) if options[:cli_password]
+      command << %Q(--password '#{options[:cli_password]}') if options[:cli_password]
 
       begin
         cmd = Mixlib::ShellOut.new(command.join(' '), command_options.merge(timeout: options[:timeout]))

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -69,7 +69,7 @@ EOH
         h[:proxy]    = proxy if proxy_given?
         h[:endpoint] = endpoint
         h[:timeout]  = timeout if timeout_given?
-        h[:cli_user] = cli_user if cli_user_given?
+        h[:cli_username] = cli_username if cli_username_given?
         h[:cli_password] = cli_password if cli_password_given?
       end
  
@@ -293,8 +293,8 @@ EOH
     #
     # @return [String]
     #
-    def cli_user
-      node['jenkins']['executor']['cli_user']
+    def cli_username
+      node['jenkins']['executor']['cli_username']
     end
 
     #
@@ -302,8 +302,8 @@ EOH
     #
     # @return [Boolean]
     #
-    def cli_user_given?
-      !!node['jenkins']['executor']['cli_user']
+    def cli_username_given?
+      !!node['jenkins']['executor']['cli_username']
     end
 
     #

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -69,8 +69,10 @@ EOH
         h[:proxy]    = proxy if proxy_given?
         h[:endpoint] = endpoint
         h[:timeout]  = timeout if timeout_given?
+        h[:cli_user] = cli_user if cli_user_given?
+        h[:cli_password] = cli_password if cli_password_given?
       end
-
+ 
       Jenkins::Executor.new(options)
     end
 
@@ -284,6 +286,42 @@ EOH
     #
     def timeout_given?
       !!node['jenkins']['executor']['timeout']
+    end
+
+    #
+    # Username used when invoking cli
+    #
+    # @return [String]
+    #
+    def cli_user
+      node['jenkins']['executor']['cli_user']
+    end
+
+    #
+    # Boolean method to determine if cli user was supplied.
+    #
+    # @return [Boolean]
+    #
+    def cli_user_given?
+      !!node['jenkins']['executor']['cli_user']
+    end
+
+    #
+    # password used when invoking cli
+    #
+    # @return [String]
+    #
+    def cli_password
+      node['jenkins']['executor']['cli_password']
+    end
+
+    #
+    # Boolean method to determine if cli password was supplied.
+    #
+    # @return [Boolean]
+    #
+    def cli_password_given?
+      !!node['jenkins']['executor']['cli_password']
     end
 
     #

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -49,6 +49,24 @@ describe Jenkins::Executor do
       end
     end
 
+    context 'when a :cli_user option is given' do
+      it 'adds --username option' do
+        subject.options[:cli_user] = 'user'
+        command = %|"java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --username user|
+        expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
+        subject.execute!('foo')
+      end
+    end
+
+    context 'when a :cli_password option is given' do
+      it 'adds --password option' do
+        subject.options[:cli_password] = 'password'
+        command = %|"java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --password user|
+        expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
+        subject.execute!('foo')
+      end
+    end
+
     context 'when a :key option is given' do
       it 'builds the correct command' do
         subject.options[:key] = '/key/path.pem'

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -49,9 +49,9 @@ describe Jenkins::Executor do
       end
     end
 
-    context 'when a :cli_user option is given' do
+    context 'when a :cli_username option is given' do
       it 'adds --username option' do
-        subject.options[:cli_user] = 'user'
+        subject.options[:cli_username] = 'user'
         command = %|"java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --username user|
         expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
         subject.execute!('foo')

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -52,7 +52,7 @@ describe Jenkins::Executor do
     context 'when a :cli_username option is given' do
       it 'adds --username option' do
         subject.options[:cli_username] = 'user'
-        command = %|"java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --username user|
+        command = %|"java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --username 'user'|
         expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
         subject.execute!('foo')
       end
@@ -61,7 +61,7 @@ describe Jenkins::Executor do
     context 'when a :cli_password option is given' do
       it 'adds --password option' do
         subject.options[:cli_password] = 'password'
-        command = %|"java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --password password|
+        command = %|"java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --password 'password'|
         expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
         subject.execute!('foo')
       end

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -61,7 +61,7 @@ describe Jenkins::Executor do
     context 'when a :cli_password option is given' do
       it 'adds --password option' do
         subject.options[:cli_password] = 'password'
-        command = %|"java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --password user|
+        command = %|"java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --password password|
         expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
         subject.execute!('foo')
       end

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -52,7 +52,7 @@ describe Jenkins::Executor do
     context 'when a :cli_username option is given' do
       it 'adds --username option' do
         subject.options[:cli_username] = 'user'
-        command = %|"java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --username 'user'|
+        command = %|"java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --username user|
         expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
         subject.execute!('foo')
       end


### PR DESCRIPTION
Intelligent optional use of username and password via executor['cli_username'] and executor['cli_password'] attributes.

Use of these first requires activation of an authentication method, else jenkins_cli will fail.