### PR TITLE
Add resource to execute groovy file against Jenkins master

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ jenkins_script 'add_authentication' do
 end
 ```
 
+### jenkins_scriptFile 
+This resource executes external groovy file against the Jenkins master. By the nature of this command, it is **not** idempotent.
+The file can be a resource of the recipe
+```ruby
+jenkins_scriptFile "initJenkins" do
+  file "/tmp/initJenkins.groovy"  
+end
+```
+
+
 ### jenkins_credentials
 **NOTE** The use of the Jenkins credentials resource requries the Jenkins credentials plugin. This plugin began shipping with Jenkins 1.536. On older Jenkins installations, you will need to install the credentials plugin at version 1.5 or higher to utilize this resource. On newer versions of Jenkins, this resource should work correctly.
 

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -143,6 +143,20 @@ module Jenkins
       file.close! if file
     end
 
+
+
+    #
+    # Same as {Executor#groovy!}, but with the script file as parameter.
+    #
+    # @see groovy!
+    #
+    def groovyFile!(script)
+      scriptFile = File.open(script)
+      execute!("groovy #{scriptFile.path}")
+    ensure
+      scriptFile.close if scriptFile
+    end
+    
     private
 
     #

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -111,6 +111,13 @@ if defined?(ChefSpec)
       resource_name)
   end
 
+  def execute_jenkins_scriptFile(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(
+      :jenkins_scriptFile,
+      :execute,
+      resource_name)
+  end
+  
   def create_jenkins_slave(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(
       :jenkins_slave,

--- a/libraries/scriptFile.rb
+++ b/libraries/scriptFile.rb
@@ -1,0 +1,62 @@
+#
+# Cookbook Name:: jenkins
+# HWRP:: scriptFile
+#
+# Author:: Ludovic SMADJA <ludovic.smadja@jalios.com>
+#
+# Copyright 2014, JALIOS SA.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative 'command'
+require_relative '_params_validate'
+
+class Chef
+  class Resource::JenkinsScriptFile < Resource::JenkinsCommand
+    # Chef attributes
+    provides :jenkins_scriptFile
+
+    # Set the resource name
+    self.resource_name = :jenkins_scriptFile
+
+    # Actions
+    actions :execute
+    default_action :execute
+    
+    # Attributes
+    attribute :file,
+      kind_of: String,
+      name_attribute: true
+  end
+end
+
+class Chef
+  class Provider::JenkinsScriptFile < Provider::JenkinsCommand
+    def load_current_resource
+      @current_resource ||= Resource::JenkinsScriptFile.new(new_resource.file)
+      super
+    end
+
+    action(:execute) do
+      converge_by("Execute script #{new_resource}") do
+        executor.groovyFile!(new_resource.file)
+      end
+    end
+  end
+end
+
+Chef::Platform.set(
+  resource: :jenkins_scriptFile,
+  provider: Chef::Provider::JenkinsScriptFile
+)


### PR DESCRIPTION
In our chef recipe, we need to execute a groovy file and the only available resource permit to execute groovy script from inside of the recipe.

I've so modified the recipe to permit to execute external fil against Jenkins master. Here's the pull request.