### PR TITLE
Conditionally use runit based on attributes

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -185,6 +185,13 @@ default['jenkins']['master'].tap do |master|
   master['log_directory'] = '/var/log/jenkins'
 
   #
+  # Whether to include the runit cookbook at all.
+  #
+  #   node.set['jenkins']['master']['runit']['enabled'] = false
+  #
+  master['runit']['enabled'] = true
+
+  #
   # The timeout passed to the runit cookbook's service resource. Override the
   # default timeout of 7 seconds. This option implies verbose.
   #

--- a/recipes/_master_war.rb
+++ b/recipes/_master_war.rb
@@ -61,12 +61,17 @@ remote_file File.join(node['jenkins']['master']['home'], 'jenkins.war') do
   checksum node['jenkins']['master']['checksum'] if node['jenkins']['master']['checksum']
   owner    node['jenkins']['master']['user']
   group    node['jenkins']['master']['group']
-  notifies :restart, 'runit_service[jenkins]'
+  if node['jenkins']['master']['runit']['enabled']
+    notifies :restart, 'runit_service[jenkins]'
+  end
 end
 
-Chef::Log.warn('Here we go with the runit service')
+# do we even use runit?
+if node['jenkins']['master']['runit']['enabled']
+  Chef::Log.warn('Here we go with the runit service')
 
-# Create runit service
-runit_service 'jenkins' do
-  sv_timeout node['jenkins']['master']['runit']['sv_timeout']
+  # Create runit service
+  runit_service 'jenkins' do
+    sv_timeout node['jenkins']['master']['runit']['sv_timeout']
+  end
 end

--- a/recipes/_master_war.rb
+++ b/recipes/_master_war.rb
@@ -52,8 +52,10 @@ directory node['jenkins']['master']['log_directory'] do
   recursive true
 end
 
-# Include runit to setup the service
-include_recipe 'runit::default'
+if node['jenkins']['master']['runit']['enabled']
+  # Include runit to setup the service
+  include_recipe 'runit::default'
+end
 
 # Download the remote WAR file
 remote_file File.join(node['jenkins']['master']['home'], 'jenkins.war') do


### PR DESCRIPTION
runit cookbook doesn't work on RHEL based systems, this makes it so that users of the cookbook can conditionally choose runit or implement their own service scripts.