### PR TITLE
windows - add optional commands prior to launching jenkins slave jar

### DIFF
--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -52,7 +52,7 @@ class Chef
       default: '052f82c167fbe68a4025bcebc19fff5f11b43576a2ec62b0415432832fa2272d'
     attribute :path,
       kind_of: String
-    attribute :pre_run_args,
+    attribute :pre_run_cmds,
       kind_of: Array,
       default: []
   end
@@ -181,7 +181,7 @@ class Chef
       @slave_bat_resource.cookbook('jenkins')
       @slave_bat_resource.source('jenkins-slave.bat.erb')
       @slave_bat_resource.variables(
-        pre_run_args:  new_resource.pre_run_args,
+        pre_run_cmds:  new_resource.pre_run_cmds,
         new_resource:  new_resource,
         java_bin:      java,
         slave_jar:     slave_jar,

--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -172,6 +172,9 @@ class Chef
       @slave_xml_resource
     end
 
+    # Create bat file from jenkins-slave.bat.erb to launches Jenkins jar as
+    # service. 
+    # Optionally run any commands in :pre_run_cmds before launching jar
     def slave_bat_resource
       return @slave_bat_resource if @slave_bat_resource
 

--- a/templates/default/jenkins-slave.bat.erb
+++ b/templates/default/jenkins-slave.bat.erb
@@ -1,4 +1,4 @@
-<% for @arg in @pre_run_args -%>
+<% for @arg in @pre_run_cmds -%>
   <%= @arg %>
 <% end -%>
 <%= @java_bin %> -Xrs <%= @new_resource.jvm_options %> -jar "<%= @slave_jar %>" -jnlpUrl <%= @jnlp_url %> <%= @jnlp_secret.nil? ? '' : "-secret #{@jnlp_secret}" %>

--- a/templates/default/jenkins-slave.bat.erb
+++ b/templates/default/jenkins-slave.bat.erb
@@ -1,0 +1,4 @@
+<% for @arg in @pre_run_args -%>
+  <%= @arg %>
+<% end -%>
+<%= @java_bin %> -Xrs <%= @new_resource.jvm_options %> -jar "<%= @slave_jar %>" -jnlpUrl <%= @jnlp_url %> <%= @jnlp_secret.nil? ? '' : "-secret #{@jnlp_secret}" %>

--- a/templates/default/jenkins-slave.xml.erb
+++ b/templates/default/jenkins-slave.xml.erb
@@ -43,8 +43,7 @@ THE SOFTWARE.
     if you'd like to run Jenkins with a specific version of Java, specify a full path to java.exe.
     The following value assumes that you have java in your PATH.
   -->
-  <executable><%= @java_bin %></executable>
-  <arguments>-Xrs <%= @new_resource.jvm_options %> -jar "<%= @slave_jar %>" -jnlpUrl <%= @jnlp_url %> <%= @jnlp_secret.nil? ? '' : "-secret #{@jnlp_secret}" %></arguments>
+  <executable>jenkins-slave.bat</executable>
   <!--
     interactive flag causes the empty black Java window to be displayed.
     I'm still debugging this.


### PR DESCRIPTION
Allow the user to specify additional commands prior to launching jenkins slave jar on Windows.

- Adds a new array attribute for jenkins_windows_slave recipe: pre_run_cmds.
- Move Jenkins jar launch command into seperate batch file, stored as erb template

On Windows, any mounts or other resources must be made available prior as part of the same user session as launching the jenkins service. The easiest way to do this is launch jenkins as part of a batch file with the commands.