### PR TITLE
Add support for running jenkins with a cert and key file for HTTPS support

### DIFF
--- a/attributes/master.rb
+++ b/attributes/master.rb
@@ -155,6 +155,22 @@ default['jenkins']['master'].tap do |master|
   master['port'] = 8080
 
   #
+  # The https_port which the Jenkins process will listen on.
+  #
+  master['https_port'] = nil
+
+  #
+  # The pem formatted cert file
+  #
+  master['pem_file'] = nil
+
+  #
+  # The pem formatted cert file
+  #
+  master['key_file'] = nil
+  
+  
+  #
   # The top-level endpoint for the Jenkins master. By default, this is a
   # "compiled" attribute from +jenkins.master.host+ and +jenkins.master.port+,
   # but you will need to change this attribute if you choose to serve Jenkins

--- a/templates/default/jenkins-config-debian.erb
+++ b/templates/default/jenkins-config-debian.erb
@@ -68,3 +68,7 @@ JENKINS_ARGS="--webroot=/var/cache/jenkins/war --httpListenAddress=$HTTP_LISTEN_
 <% if node['jenkins']['master']['jenkins_args'] %>
 JENKINS_ARGS="$JENKINS_ARGS <%= node['jenkins']['master']['jenkins_args'] %>"
 <% end %>
+<% if node['jenkins']['master']['https_port'] && node['jenkins']['master']['pem_file'] && node['jenkins']['master']['key_file'] %>
+JENKINS_ARGS="$JENKINS_ARGS --httpsCertificate=<% node['jenkins']['master']['pem_file'] %> --httpsPrivateKey=<%= node['jenkins']['master']['key_file'] %>  --httpsPort=<%= node['jenkins']['master']['https_port'] %>"
+<% end %>
+

--- a/templates/default/jenkins-config-rhel.erb
+++ b/templates/default/jenkins-config-rhel.erb
@@ -69,7 +69,7 @@ JENKINS_LISTEN_ADDRESS="<%= node['jenkins']['master']['listen_address'] %>"
 # HTTPS port Jenkins is listening on.
 # Default is disabled.
 #
-JENKINS_HTTPS_PORT=""
+JENKINS_HTTPS_PORT="<%= node['jenkins']['master']['https_port'] %>"
 
 ## Type:        string
 ## Default:     ""
@@ -141,3 +141,10 @@ JENKINS_HANDLER_IDLE="20"
 <% if node['jenkins']['master']['jenkins_args'] %>
 JENKINS_ARGS="$JENKINS_ARGS <%= node['jenkins']['master']['jenkins_args'] %>"
 <% end %>
+#
+# If https_port, pem_file and key_file are ALL set add it to JENKINS_ARGS
+#
+<% if node['jenkins']['master']['https_port'] && node['jenkins']['master']['pem_file'] && node['jenkins']['master']['key_file'] %>
+JENKINS_ARGS="$JENKINS_ARGS --httpsCertificate=<%= node['jenkins']['master']['pem_file'] %> --httpsPrivateKey=<%= node['jenkins']['master']['key_file'] %>  --httpsPort=<%= node['jenkins']['master']['https_port'] %>"
+<% end %>
+

--- a/templates/default/sv-jenkins-run.erb
+++ b/templates/default/sv-jenkins-run.erb
@@ -15,4 +15,8 @@ exec chpst -u <%= node['jenkins']['master']['user'] %> -U <%= node['jenkins']['m
   <%= node['jenkins']['java'] %> <%= node['jenkins']['master']['jvm_options'] %> -jar jenkins.war \
   --httpPort=<%= node['jenkins']['master']['port'] %> \
   --httpListenAddress=<%= node['jenkins']['master']['listen_address'] %> \
+<% if node['jenkins']['master']['https_port'] && node['jenkins']['master']['pem_file'] && node['jenkins']['master']['key_file'] %>
+  --httpsCertificate=<%= node['jenkins']['master']['pem_file'] %> --httpsPrivateKey=<%= node['jenkins']['master']['key_file'] %>  --httpsPort=<%= node['jenkins']['master']['https_port'] %> \
+<% end %>
   <%= node['jenkins']['master']['jenkins_args'] %>
+


### PR DESCRIPTION
If you set these three attributes then the service config files will add --httpsCertificate --httpsPrivateKey and --httpsPort.
master['https_port'] = nil
master['pem_file'] = nil
master['key_file'] = nil

If you set https_port to -1 you can disable https but then all the tests break.

smoke tests ran clean but not consistent.