### PR TITLE
Add jenkins_cli username/password support

### DIFF
--- a/attributes/executor.rb
+++ b/attributes/executor.rb
@@ -44,4 +44,20 @@ default['jenkins']['executor'].tap do |executor|
   # Please see the +Proxies+ section of the README for more information.
   #
   executor['proxy'] = nil
+
+  #
+  # This is the user name you wish to use to authenticate with the Jenkins CLI
+  # If left nil, no user will be specified (anonymous).
+  # It is best to set this in a spot within your cookbook after an authentication scheme is activated
+  # Otherwise, Jenkins wont understand the --username flag
+  #
+  executor['cli_username'] = nil
+
+  #
+  # This is the user name you wish to use to authenticate with the Jenkins CLI
+  # If left nil, no password will be used.
+  # It is best to set this in a spot within your cookbook after an authentication scheme is activated
+  # Otherwise, Jenkins wont understand the --password flag
+  #
+  executor['cli_password'] = nil
 end

--- a/libraries/_executor.rb
+++ b/libraries/_executor.rb
@@ -75,6 +75,8 @@ module Jenkins
       command << %Q(-i "#{options[:key]}")                if options[:key]
       command << %Q(-p #{uri_escape(options[:proxy])})    if options[:proxy]
       command.push(pieces)
+      command << %Q(--username #{options[:cli_username]}) if options[:cli_username]
+      command << %Q(--password '#{options[:cli_password]}') if options[:cli_password]
 
       begin
         cmd = Mixlib::ShellOut.new(command.join(' '), command_options.merge(timeout: options[:timeout]))

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -69,6 +69,8 @@ EOH
         h[:proxy]    = proxy if proxy_given?
         h[:endpoint] = endpoint
         h[:timeout]  = timeout if timeout_given?
+        h[:cli_username] = cli_username if cli_username_given?
+        h[:cli_password] = cli_password if cli_password_given?
       end
 
       Jenkins::Executor.new(options)
@@ -284,6 +286,41 @@ EOH
     #
     def timeout_given?
       !!node['jenkins']['executor']['timeout']
+    end
+
+    # Username used when invoking cli
+    #
+    # @return [String]
+    #
+    def cli_username
+      node['jenkins']['executor']['cli_username']
+    end
+
+    #
+    # Boolean method to determine if cli user was supplied.
+    #
+    # @return [Boolean]
+    #
+    def cli_username_given?
+      !!node['jenkins']['executor']['cli_username']
+    end
+
+    #
+    # password used when invoking cli
+    #
+    # @return [String]
+    #
+    def cli_password
+      node['jenkins']['executor']['cli_password']
+    end
+
+    #
+    # Boolean method to determine if cli password was supplied.
+    #
+    # @return [Boolean]
+    #
+    def cli_password_given?
+      !!node['jenkins']['executor']['cli_password']
     end
 
     #

--- a/spec/libraries/executor_spec.rb
+++ b/spec/libraries/executor_spec.rb
@@ -49,6 +49,24 @@ describe Jenkins::Executor do
       end
     end
 
+    context 'when a :cli_username option is given' do
+      it 'adds --username option' do
+        subject.options[:cli_username] = 'user'
+        command = %|"java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --username user|
+        expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
+        subject.execute!('foo')
+      end
+    end
+
+    context 'when a :cli_password option is given' do
+      it 'adds --password option' do
+        subject.options[:cli_password] = 'password'
+        command = %|"java" -jar "/usr/share/jenkins/cli/java/cli.jar" foo --password 'password'|
+        expect(Mixlib::ShellOut).to receive(:new).with(command, timeout: 60)
+        subject.execute!('foo')
+      end
+    end
+
     context 'when a :key option is given' do
       it 'builds the correct command' do
         subject.options[:key] = '/key/path.pem'


### PR DESCRIPTION
This will add optional username and password support to jenkins_cli
@jtimberman 
rebase/squash of [#326](https://github.com/opscode-cookbooks/jenkins/pull/326)