### PR TITLE
Need to escape the \n when there are multiple public keys so that the groovy script sees the literal \n, not the newline.

### DIFF
--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -103,7 +103,7 @@ class Chef
             password = hudson.security.HudsonPrivateSecurityRealm.Details.fromPlainPassword('#{new_resource.password}')
             user.addProperty(password)
 
-            keys = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl('#{new_resource.public_keys.join("\n")}')
+            keys = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl('#{new_resource.public_keys.join("\\n")}')
             user.addProperty(keys)
 
             user.save()


### PR DESCRIPTION
I did a 'bundle exec rake' on the master before making my change but it failed trying to converge smoke-package-centos-64.
Without the change, my wrapper cookbook throws a groovy syntax error in jenkins_user if there are two or more public keys being added because of the newline between the multiple keys. When joined with \n the groovy script sees only one line & correctly inserts the multiple keys into the user object.