### PR TITLE
Download update center metadata every time

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -411,7 +411,7 @@ EOH
         # check if the resource responds to the method before calling it.
         remote_file.sensitive(true) if remote_file.respond_to?(:sensitive)
         remote_file.mode('0644')
-        remote_file.run_action(:create_if_missing)
+        remote_file.run_action(:create)
 
         extracted_json = ''
 


### PR DESCRIPTION
When not specifying a version in `jenkins_plugin`:
Previous behavior caused cookbook to downgrade plugins (effectively freezing the latest at the first chef run).
New behavior is to upgrade plugins to latest.
Also caused bugs when specifying a version higher than was available at first chef run.