### PR TITLE
Re-enable lazy attribute defaults in LWRP workaround for Chef 11

### DIFF
--- a/libraries/_params_validate.rb
+++ b/libraries/_params_validate.rb
@@ -20,41 +20,44 @@
 #
 
 #
-# HACK: https://github.com/chef/chef/pull/1559
-# This file can be removed when PR #1559 is merged.
+# This workaround is only needed on Chef versions prior to 12.0.0:
 #
-require 'chef/mixin/params_validate'
-class Chef
-  module Mixin::ParamsValidate
-    def set_or_return(symbol, arg, validation)
-      iv_symbol = "@#{symbol}".to_sym
-      if arg.nil? && self.instance_variable_defined?(iv_symbol) == true
-        ivar = instance_variable_get(iv_symbol)
-        if ivar.is_a?(DelayedEvaluator)
-          validate({ symbol => ivar.call }, { symbol => validation })[symbol] # rubocop:disable BracesAroundHashParameters
+#   https://github.com/chef/chef/pull/1559
+#
+if Gem::Requirement.new('< 12.0').satisfied_by?(Gem::Version.new(Chef::VERSION))
+  require 'chef/mixin/params_validate'
+  class Chef
+    module Mixin::ParamsValidate
+      def set_or_return(symbol, arg, validation)
+        iv_symbol = "@#{symbol}".to_sym
+        if arg.nil? && self.instance_variable_defined?(iv_symbol) == true
+          ivar = instance_variable_get(iv_symbol)
+          if ivar.is_a?(DelayedEvaluator)
+            validate({ symbol => ivar.call }, { symbol => validation })[symbol] # rubocop:disable BracesAroundHashParameters
+          else
+            ivar
+          end
         else
-          ivar
-        end
-      else
-        if arg.is_a?(DelayedEvaluator)
-          val = arg
-        else
-          val = validate({ symbol => arg }, { symbol => validation })[symbol] # rubocop:disable BracesAroundHashParameters
+          if arg.is_a?(DelayedEvaluator)
+            val = arg
+          else
+            val = validate({ symbol => arg }, { symbol => validation })[symbol] # rubocop:disable BracesAroundHashParameters
 
-          # Handle the case where the "default" was a DelayedEvaluator
-          val = val.call(self) if val.is_a?(DelayedEvaluator)
+            # Handle the case where the "default" was a DelayedEvaluator
+            val = val.call(self) if val.is_a?(DelayedEvaluator) # rubocop:disable BlockNesting
+          end
+          instance_variable_set(iv_symbol, val)
         end
-        instance_variable_set(iv_symbol, val)
       end
     end
   end
-end
 
-require 'chef/resource/lwrp_base'
-class Chef
-  class Resource::LWRPBase
-    def self.lazy(&block)
-      DelayedEvaluator.new(&block)
+  require 'chef/resource/lwrp_base'
+  class Chef
+    class Resource::LWRPBase
+      def self.lazy(&block)
+        DelayedEvaluator.new(&block)
+      end
     end
   end
 end

--- a/libraries/_params_validate.rb
+++ b/libraries/_params_validate.rb
@@ -1,0 +1,60 @@
+#
+# Cookbook Name:: jenkins
+# Library:: params_validate
+#
+# Author:: Seth Vargo <sethvargo@gmail.com>
+#
+# Copyright 2013-2014, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# HACK: https://github.com/chef/chef/pull/1559
+# This file can be removed when PR #1559 is merged.
+#
+require 'chef/mixin/params_validate'
+class Chef
+  module Mixin::ParamsValidate
+    def set_or_return(symbol, arg, validation)
+      iv_symbol = "@#{symbol}".to_sym
+      if arg.nil? && self.instance_variable_defined?(iv_symbol) == true
+        ivar = instance_variable_get(iv_symbol)
+        if ivar.is_a?(DelayedEvaluator)
+          validate({ symbol => ivar.call }, { symbol => validation })[symbol] # rubocop:disable BracesAroundHashParameters
+        else
+          ivar
+        end
+      else
+        if arg.is_a?(DelayedEvaluator)
+          val = arg
+        else
+          val = validate({ symbol => arg }, { symbol => validation })[symbol] # rubocop:disable BracesAroundHashParameters
+
+          # Handle the case where the "default" was a DelayedEvaluator
+          val = val.call(self) if val.is_a?(DelayedEvaluator)
+        end
+        instance_variable_set(iv_symbol, val)
+      end
+    end
+  end
+end
+
+require 'chef/resource/lwrp_base'
+class Chef
+  class Resource::LWRPBase
+    def self.lazy(&block)
+      DelayedEvaluator.new(&block)
+    end
+  end
+end

--- a/libraries/command.rb
+++ b/libraries/command.rb
@@ -20,6 +20,7 @@
 #
 
 require_relative '_helper'
+require_relative '_params_validate'
 
 class Chef
   class Resource::JenkinsCommand < Resource::LWRPBase

--- a/libraries/credentials.rb
+++ b/libraries/credentials.rb
@@ -20,6 +20,7 @@
 #
 
 require_relative '_helper'
+require_relative '_params_validate'
 
 class Chef
   class Resource::JenkinsCredentials < Resource::LWRPBase
@@ -53,7 +54,9 @@ class Chef
               default: lazy { SecureRandom.uuid }
     attribute :description,
               kind_of: String,
-              default: lazy { |new_resource| "Credentials for #{new_resource.username} - created by Chef" }
+              default: lazy do |new_resource|
+                "Credentials for #{new_resource.username} - created by Chef"
+              end
 
     attr_writer :exists
 

--- a/libraries/credentials.rb
+++ b/libraries/credentials.rb
@@ -54,9 +54,7 @@ class Chef
               default: lazy { SecureRandom.uuid }
     attribute :description,
               kind_of: String,
-              default: lazy do |new_resource|
-                "Credentials for #{new_resource.username} - created by Chef"
-              end
+              default: lazy { |new_resource| "Credentials for #{new_resource.username} - created by Chef" }
 
     attr_writer :exists
 

--- a/libraries/credentials_password.rb
+++ b/libraries/credentials_password.rb
@@ -20,6 +20,7 @@
 #
 
 require_relative 'credentials'
+require_relative '_params_validate'
 
 class Chef
   class Resource::JenkinsPasswordCredentials < Resource::JenkinsCredentials

--- a/libraries/credentials_private_key.rb
+++ b/libraries/credentials_private_key.rb
@@ -20,6 +20,7 @@
 #
 
 require_relative 'credentials'
+require_relative '_params_validate'
 
 class Chef
   class Resource::JenkinsPrivateKeyCredentials < Resource::JenkinsCredentials

--- a/libraries/job.rb
+++ b/libraries/job.rb
@@ -20,6 +20,7 @@
 #
 
 require_relative '_helper'
+require_relative '_params_validate'
 
 class Chef
   class Resource::JenkinsJob < Resource::LWRPBase

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -23,6 +23,7 @@
 require 'digest'
 
 require_relative '_helper'
+require_relative '_params_validate'
 
 class Chef
   class Resource::JenkinsPlugin < Resource::LWRPBase

--- a/libraries/script.rb
+++ b/libraries/script.rb
@@ -20,6 +20,7 @@
 #
 
 require_relative 'command'
+require_relative '_params_validate'
 
 class Chef
   class Resource::JenkinsScript < Resource::JenkinsCommand

--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -43,9 +43,7 @@ class Chef
               name_attribute: true
     attribute :description,
               kind_of: String,
-              default: lazy do |new_resource|
-                "Jenkins slave #{new_resource.slave_name}"
-              end
+              default: lazy { |new_resource| "Jenkins slave #{new_resource.slave_name}" }
     attribute :remote_fs,
               kind_of: String,
               default: '/home/jenkins'

--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -20,6 +20,7 @@
 #
 
 require_relative '_helper'
+require_relative '_params_validate'
 
 require 'json'
 
@@ -42,7 +43,9 @@ class Chef
               name_attribute: true
     attribute :description,
               kind_of: String,
-              default: lazy { |new_resource| "Jenkins slave #{new_resource.slave_name}" }
+              default: lazy do |new_resource|
+                "Jenkins slave #{new_resource.slave_name}"
+              end
     attribute :remote_fs,
               kind_of: String,
               default: '/home/jenkins'

--- a/libraries/slave_jnlp.rb
+++ b/libraries/slave_jnlp.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 
+require_relative '_params_validate'
 require_relative 'slave'
 
 class Chef

--- a/libraries/slave_ssh.rb
+++ b/libraries/slave_ssh.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 
+require_relative '_params_validate'
 require_relative 'slave'
 require_relative 'credentials'
 

--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 
+require_relative '_params_validate'
 require_relative 'slave'
 require_relative 'slave_jnlp'
 

--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -20,6 +20,7 @@
 #
 
 require_relative '_helper'
+require_relative '_params_validate'
 
 class Chef
   class Resource::JenkinsUser < Resource::LWRPBase


### PR DESCRIPTION
This re-enables the lazy attribute defaults in LWRP workaround that was removed with 35cee51. Additionally the workaround/hack is only applied on Chef versions < 12 as the issue was fixed with chef/chef#1559.

This fixes #358.
