### PR TITLE
Always create the Jenkins home directory so Jenkins won't fail to start

### DIFF
--- a/recipes/_master_war.rb
+++ b/recipes/_master_war.rb
@@ -36,14 +36,6 @@ group node['jenkins']['master']['group'] do
   system node['jenkins']['master']['use_system_accounts'] # ~FC048
 end
 
-# Create the home directory
-directory node['jenkins']['master']['home'] do
-  owner     node['jenkins']['master']['user']
-  group     node['jenkins']['master']['group']
-  mode      '0755'
-  recursive true
-end
-
 # Create the log directory
 directory node['jenkins']['master']['log_directory'] do
   owner     node['jenkins']['master']['user']

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -26,6 +26,14 @@
 # limitations under the License.
 #
 
+# Create the home directory
+directory node['jenkins']['master']['home'] do
+  owner     node['jenkins']['master']['user']
+  group     node['jenkins']['master']['group']
+  mode      '0755'
+  recursive true
+end
+
 # Gracefully handle the failure for an invalid installation type
 begin
   include_recipe "jenkins::_master_#{node['jenkins']['master']['install_method']}"


### PR DESCRIPTION
This fixes issues with changing the home directory on a package install.  The sysconfig file is updated with the new path but Jenkins will fail to start because the directory may not exist or it may exist but with incorrect permissions.

To fix this, the simplest solution is to simply always create the directory with the appropriate permissions regardless of whether installing via WAR or package.