### PR TITLE
Ensure Jenkins home directory has correct ownership after package installation.

### DIFF
--- a/recipes/_master_package.rb
+++ b/recipes/_master_package.rb
@@ -52,8 +52,8 @@ when 'rhel'
     version node['jenkins']['master']['version']
   end
 
-  #The package install creates the Jenkins user so now is the time to set the home
-  #directory permissions.
+  # The package install creates the Jenkins user so now is the time to set the home
+  # directory permissions.
   directory node['jenkins']['master']['home'] do
     owner     node['jenkins']['master']['user']
     group     node['jenkins']['master']['group']

--- a/recipes/_master_package.rb
+++ b/recipes/_master_package.rb
@@ -52,6 +52,15 @@ when 'rhel'
     version node['jenkins']['master']['version']
   end
 
+  #The package install creates the Jenkins user so now is the time to set the home
+  #directory permissions.
+  directory node['jenkins']['master']['home'] do
+    owner     node['jenkins']['master']['user']
+    group     node['jenkins']['master']['group']
+    mode      '0755'
+    recursive true
+  end
+
   template '/etc/sysconfig/jenkins' do
     source   'jenkins-config-rhel.erb'
     mode     '0644'


### PR DESCRIPTION
This fixes issues with specifying a non-default home directory on a package install.

Must delay directory creation until after package installation is completed to ensure "jenkins" user exists.