### PR TITLE
Issue 378 Fix for NPE when creating already registered slave with env vars defined

### DIFF
--- a/libraries/slave.rb
+++ b/libraries/slave.rb
@@ -331,7 +331,7 @@ class Chef
           executors:slave.numExecutors.toInteger(),
           usage_mode:slave.mode.toString().toLowerCase(),
           labels:slave.labelString.split().sort(),
-          environment:slave.nodeProperties.get(EnvironmentVariablesNodeProperty.class)?.envVars,
+          environment:new java.util.HashMap<String,String>(slave.nodeProperties.get(EnvironmentVariablesNodeProperty.class)?.envVars),
           connected:(slave.computer.connectTime > 0),
           online:slave.computer.online
         ]


### PR DESCRIPTION
This is fix for the issue #378

After investigation I found that [Jenkins Class EnvVars](http://javadoc.jenkins-ci.org/hudson/EnvVars.html) extends TreeMap<String,String>. For some reason, [groovy.json.JsonBuilder](http://docs.groovy-lang.org/latest/html/gapi/groovy/json/JsonBuilder.html) cannot parse TreeMap<String,String> object, and silently fails, thus creating a new Object returns null. In result, the groovy script sent to Jenkins by the cookbook fails with exception below, because later there is a reference to the object (println(builder)) without checking if it exists.
However the JsonBuilder class parses HashMap well. So, in order to fix this issue, I copy data from TreeMap object to HashMap one and pass it to the JsonBuilder. After that it started working as expected.

Groovy exception:
```
[name:ci-platform-slave01, description:Jenkins slave ci-platform-slave01, remote_fs:/opt/jenkins_home, executors:10, usage_mode:normal, labels:[], environment:[a:b], connected:false, online:true, availability:always]
java.lang.NullPointerException
	at hudson.util.CaseInsensitiveComparator.compare(CaseInsensitiveComparator.java:40)
	at hudson.util.CaseInsensitiveComparator.compare(CaseInsensitiveComparator.java:34)
	at java.util.TreeMap.getEntryUsingComparator(TreeMap.java:369)
	at java.util.TreeMap.getEntry(TreeMap.java:340)
	at java.util.TreeMap.containsKey(TreeMap.java:227)
	at java_util_Map$containsKey.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:42)
	at java_util_Map$containsKey.call(Unknown Source)
	at groovy.json.JsonOutput.toJson(JsonOutput.groovy:142)
	at groovy.json.JsonOutput$toJson.callStatic(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallStatic(CallSiteArray.java:50)
	at groovy.json.JsonOutput$toJson$2.callStatic(Unknown Source)
	at groovy.json.JsonOutput$_toJson_closure2.doCall(JsonOutput.groovy:145)
	at sun.reflect.GeneratedMethodAccessor236.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:233)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:272)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:884)
	at groovy.lang.Closure.call(Closure.java:412)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.callClosureForMapEntry(DefaultGroovyMethods.java:3491)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.collect(DefaultGroovyMethods.java:2229)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.collect(DefaultGroovyMethods.java:2246)
	at org.codehaus.groovy.runtime.dgm$79.invoke(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:271)
	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:53)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116)
	at groovy.json.JsonOutput.toJson(JsonOutput.groovy:145)
	at groovy.json.JsonOutput$toJson.call(Unknown Source)
	at groovy.json.JsonBuilder.toString(JsonBuilder.groovy:242)
	at org.codehaus.groovy.runtime.InvokerHelper.format(InvokerHelper.java:550)
	at org.codehaus.groovy.runtime.InvokerHelper.format(InvokerHelper.java:504)
	at org.codehaus.groovy.runtime.InvokerHelper.toString(InvokerHelper.java:114)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.println(DefaultGroovyMethods.java:606)
	at org.codehaus.groovy.runtime.dgm$594.doMethodInvoke(Unknown Source)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1054)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:884)
	at org.codehaus.groovy.runtime.InvokerHelper.invokePojoMethod(InvokerHelper.java:781)
	at org.codehaus.groovy.runtime.InvokerHelper.invokeMethod(InvokerHelper.java:772)
	at groovy.lang.Script.println(Script.java:159)
	at groovy.lang.Script$println.callCurrent(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:46)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:133)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:141)
	at Script1.run(Script1.groovy:36)
	at groovy.lang.GroovyShell.evaluate(GroovyShell.java:580)
	at groovy.lang.GroovyShell.evaluate(GroovyShell.java:618)
	at groovy.lang.GroovyShell.evaluate(GroovyShell.java:589)
	at hudson.util.RemotingDiagnostics$Script.call(RemotingDiagnostics.java:150)
	at hudson.util.RemotingDiagnostics$Script.call(RemotingDiagnostics.java:122)
	at hudson.remoting.LocalChannel.call(LocalChannel.java:45)
	at hudson.util.RemotingDiagnostics.executeGroovy(RemotingDiagnostics.java:119)
	at jenkins.model.Jenkins._doScript(Jenkins.java:3393)
	at jenkins.model.Jenkins.doScript(Jenkins.java:3370)
	at sun.reflect.GeneratedMethodAccessor267.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:297)
	at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:160)
	at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:95)
	at org.kohsuke.stapler.MetaClass$1.doDispatch(MetaClass.java:111)
	at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:53)
	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:685)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:799)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:587)
	at org.kohsuke.stapler.Stapler.service(Stapler.java:218)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:728)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:305)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210)
	at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:95)
	at net.bull.javamelody.MonitoringFilter.doFilter(MonitoringFilter.java:203)
	at net.bull.javamelody.MonitoringFilter.doFilter(MonitoringFilter.java:181)
	at net.bull.javamelody.PluginMonitoringFilter.doFilter(PluginMonitoringFilter.java:86)
	at org.jvnet.hudson.plugins.monitoring.HudsonMonitoringFilter.doFilter(HudsonMonitoringFilter.java:90)
	at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:98)
	at hudson.plugins.greenballs.GreenBallFilter.doFilter(GreenBallFilter.java:58)
	at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:98)
	at hudson.util.PluginServletFilter.doFilter(PluginServletFilter.java:87)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:243)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210)
	at hudson.security.csrf.CrumbFilter.doFilter(CrumbFilter.java:48)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:243)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:84)
	at hudson.security.UnwrapSecurityExceptionFilter.doFilter(UnwrapSecurityExceptionFilter.java:51)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at org.acegisecurity.ui.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:124)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at org.acegisecurity.providers.anonymous.AnonymousProcessingFilter.doFilter(AnonymousProcessingFilter.java:125)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at org.acegisecurity.ui.rememberme.RememberMeProcessingFilter.doFilter(RememberMeProcessingFilter.java:142)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at org.acegisecurity.ui.AbstractProcessingFilter.doFilter(AbstractProcessingFilter.java:271)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at org.acegisecurity.ui.basicauth.BasicProcessingFilter.doFilter(BasicProcessingFilter.java:174)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at jenkins.security.ApiTokenFilter.doFilter(ApiTokenFilter.java:64)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at org.acegisecurity.context.HttpSessionContextIntegrationFilter.doFilter(HttpSessionContextIntegrationFilter.java:249)
	at hudson.security.HttpSessionContextIntegrationFilter2.doFilter(HttpSessionContextIntegrationFilter2.java:66)
	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
	at hudson.security.ChainedServletFilter.doFilter(ChainedServletFilter.java:76)
	at hudson.security.HudsonFilter.doFilter(HudsonFilter.java:164)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:243)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210)
	at org.kohsuke.stapler.compression.CompressionFilter.doFilter(CompressionFilter.java:46)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:243)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210)
	at hudson.util.CharacterEncodingFilter.doFilter(CharacterEncodingFilter.java:81)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:243)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:222)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:123)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:472)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:171)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:99)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:118)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:407)
	at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1004)
	at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:589)
	at org.apache.tomcat.util.net.JIoEndpoint$SocketProcessor.run(JIoEndpoint.java:312)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)

```