### PR TITLE
If the installed plugin version is a SNAPSHOT let it be

### DIFF
--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -143,10 +143,14 @@ EOH
         else
           current_version = plugin_version(current_resource.version)
 
-          if current_version < desired_version
-            converge_by("Upgrade #{new_resource} from #{current_resource.version} to #{desired_version}", &install_block)
-          else
-            converge_by("Downgrade #{new_resource} from #{current_resource.version} to #{desired_version}", &downgrade_block)
+          unless current_version.to_s.include? 'SNAPSHOT'
+            if current_version < desired_version
+              puts "current_version < desired_version"
+              converge_by("Upgrade #{new_resource} from #{current_resource.version} to #{desired_version}", &install_block)
+            else
+              puts "current_version > desired_version"
+              converge_by("Downgrade #{new_resource} from #{current_resource.version} to #{desired_version}", &downgrade_block)
+            end
           end
         end
       else


### PR DESCRIPTION
The whole plugin version checking system is busted, even the existing test in [test/fixtures/cookbooks/jenkins_plugin/recipes/install.rb] is a false positive because this test:
```
# Install with a wacky version number
jenkins_plugin 'build-monitor-plugin' do
  version '1.6+build.135'
  install_deps true
  notifies :restart, 'service[jenkins]'
end
```
Will fail if the build-monitor-plugin already existed on the Jenkins server, reason being that on line 140 of the plugin resource the following test is done:
```
if current_resource.installed?
```
Which returns false in the case of the test run.

This fix at least will not kill a chef-client run on a server that has SNAPSHOT builds of plugins installed, not perfect but better than not being able to develop plugins at all on a jenkins server managed by chef.