### PR TITLE
Make slave_exe resource only get created if it is missing on Windows.

### DIFF
--- a/libraries/slave_windows.rb
+++ b/libraries/slave_windows.rb
@@ -76,7 +76,12 @@ class Chef
       #  * remote_fs_dir_resource
       #  * slave_jar_resource
       #
-      slave_exe_resource.run_action(:create)
+
+      # The jenkins-slave.exe is needed to get the slave up and running under a windows service.
+      # However, once it is created Jenkins Master wants to control the version.  So we should only
+      # create the file if it is missing.
+      slave_exe_resource.run_action(:create_if_missing)
+
       slave_compat_xml.run_action(:create)
       slave_bat_resource.run_action(:create)
       slave_xml_resource.run_action(:create)


### PR DESCRIPTION
Since the jenkins-slave.exe is being controlled by [Jenkins](https://github.com/jenkinsci/windows-slave-installer-module) Chef should just worry about deploying it once and getting it up and running

See master trying to overwrite(from Jenkins Log UI):
![image](https://cloud.githubusercontent.com/assets/6966179/9691519/dc14164a-5310-11e5-8fdc-61f80ed122f7.png)


Without this change the Chef code and Jenkins code keep redeploying the same file.  This also fixes #399 